### PR TITLE
in response to https://github.com/jguertl/SharePlugin/issues/54

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,4 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+ShareAll.userprefs

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ public class ShareOptions
     /// If null (default) the value of <see cref="Plugin.Share.ShareImplementation.ExcludedUIActivityTypes"/> is used.
     /// </summary>
     public ShareUIActivityType[] ExcludedUIActivityTypes { get; set; } = null;
+
+    /// <summary>
+    /// iOS only: Gets or sets the popover anchor rectangle.
+    /// If null (default) the option is not used.
+    /// </summary>
+    public ShareRect PopoverAnchorRect { get; set; } = null;
 }
 ```
 
@@ -192,6 +198,7 @@ new ShareOptions
 {
 	ChooserTitle = "Chooser Title",
 	ExcludedUIActivityTypes = new [] { ShareUIActivityType.PostToFacebook }
+    PopoverAnchorRect = new ShareRect(100, 100, 50, 20)
 });
 ```
 

--- a/Share/Share.Plugin.Abstractions/Share.Plugin.Abstractions.csproj
+++ b/Share/Share.Plugin.Abstractions/Share.Plugin.Abstractions.csproj
@@ -45,6 +45,7 @@
     <Compile Include="ShareMessage.cs" />
     <Compile Include="ShareOptions.cs" />
     <Compile Include="ShareUIActivityType.cs" />
+    <Compile Include="ShareRect.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Share/Share.Plugin.Abstractions/ShareOptions.cs
+++ b/Share/Share.Plugin.Abstractions/ShareOptions.cs
@@ -22,5 +22,13 @@ namespace Plugin.Share.Abstractions
         /// If null (default) the value of <see cref="Plugin.Share.ShareImplementation.ExcludedUIActivityTypes"/> is used.
         /// </summary>
         public ShareUIActivityType[] ExcludedUIActivityTypes { get; set; } = null;
+
+        /// <summary>
+        /// iOS only: Gets or sets the popover anchor rectangle.
+        /// If null (default) option is not used.
+        /// </summary>
+        /// <value>The source object.</value>
+        public ShareRect PopoverAnchorRect { get; set; } = null;
     }
+
 }

--- a/Share/Share.Plugin.Abstractions/ShareOptions.cs
+++ b/Share/Share.Plugin.Abstractions/ShareOptions.cs
@@ -25,9 +25,8 @@ namespace Plugin.Share.Abstractions
 
         /// <summary>
         /// iOS only: Gets or sets the popover anchor rectangle.
-        /// If null (default) option is not used.
+        /// If null (default) the option is not used.
         /// </summary>
-        /// <value>The source object.</value>
         public ShareRect PopoverAnchorRect { get; set; } = null;
     }
 

--- a/Share/Share.Plugin.Abstractions/ShareRect.cs
+++ b/Share/Share.Plugin.Abstractions/ShareRect.cs
@@ -1,0 +1,19 @@
+﻿using System;
+namespace Plugin.Share.Abstractions
+{
+    public class ShareRect
+    {
+        public readonly double X;
+        public readonly double Y;
+        public readonly double Width;
+        public readonly double Height;
+
+        public ShareRect(double x, double y, double width, double height)
+        {
+            X = x;
+            Y = y;
+            Width = width;
+            Height = height;
+        }
+    }
+}

--- a/Share/Share.Plugin.iOSUnified/ShareImplementation.cs
+++ b/Share/Share.Plugin.iOSUnified/ShareImplementation.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using UIKit;
+using CoreGraphics;
 
 namespace Plugin.Share
 {
@@ -130,6 +131,10 @@ namespace Plugin.Share
                     if (activityController.PopoverPresentationController != null)
                     {
                         activityController.PopoverPresentationController.SourceView = vc.View;
+                        var rect = options?.PopoverAnchorRect;
+                        if (rect != null) {
+                            activityController.PopoverPresentationController.SourceRect = new CGRect(rect.X, rect.Y, rect.Width, rect.Height);
+                        }
                     }
                 }
 
@@ -143,6 +148,7 @@ namespace Plugin.Share
                 return false;
             }
         }
+
 
         /// <summary>
         /// Gets the visible view controller.

--- a/ShareTest/ShareTest.Droid/ShareTest.Droid.csproj
+++ b/ShareTest/ShareTest.Droid/ShareTest.Droid.csproj
@@ -50,10 +50,6 @@
     <AndroidLinkMode>SdkOnly</AndroidLinkMode>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FormsViewGroup">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.2.127\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Mono.Android" />
     <Reference Include="mscorlib" />
     <Reference Include="Plugin.CurrentActivity, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
@@ -100,21 +96,20 @@
       <HintPath>..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.2.127\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FormsViewGroup">
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.2.127\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Xamarin.Forms.Core">
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.Android">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.2.127\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform">
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.2.127\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -148,6 +143,7 @@
     </ProjectReference>
     <ProjectReference Include="..\ShareTest\ShareTest.csproj">
       <Name>ShareTest</Name>
+      <Project>{0F183FA6-5A54-4CE7-810A-801937115DE3}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
@@ -156,15 +152,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets'))" />
   </Target>
   <Import Project="..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" />
-  <Import Project="..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-     Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <Import Project="..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/ShareTest/ShareTest.Droid/packages.config
+++ b/ShareTest/ShareTest.Droid/packages.config
@@ -10,5 +10,5 @@
   <package id="Xamarin.Android.Support.v7.MediaRouter" version="23.3.0" targetFramework="monoandroid60" />
   <package id="Xamarin.Android.Support.v7.RecyclerView" version="23.3.0" targetFramework="monoandroid60" />
   <package id="Xamarin.Android.Support.Vector.Drawable" version="23.3.0" targetFramework="monoandroid60" />
-  <package id="Xamarin.Forms" version="2.3.2.127" targetFramework="monoandroid60" />
+  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="monoandroid60" />
 </packages>

--- a/ShareTest/ShareTest.iOS/ShareTest.iOS.csproj
+++ b/ShareTest/ShareTest.iOS/ShareTest.iOS.csproj
@@ -114,6 +114,7 @@
     </ProjectReference>
     <ProjectReference Include="..\ShareTest\ShareTest.csproj">
       <Name>ShareTest</Name>
+      <Project>{0F183FA6-5A54-4CE7-810A-801937115DE3}</Project>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -144,30 +145,20 @@
     <Reference Include="System.Core">
       <HintPath>..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\Xamarin.iOS\v1.0\System.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Xamarin.iOS" />
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.2.127\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.2.127\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.iOS">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.2.127\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.2.127\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets'))" />
-  </Target>
-  <Import Project="..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+  <Import Project="..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/ShareTest/ShareTest.iOS/packages.config
+++ b/ShareTest/ShareTest.iOS/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.3.2.127" targetFramework="xamarinios10" />
+  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="xamarinios10" />
 </packages>

--- a/ShareTest/ShareTest/App.cs
+++ b/ShareTest/ShareTest/App.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 
 using Xamarin.Forms;
+using ShareTest.Extensions;
 
 namespace ShareTest
 {
@@ -58,9 +59,10 @@ namespace ShareTest
                 new ShareOptions
                 {
                     ChooserTitle = "Chooser Title",
-                    ExcludedUIActivityTypes = new [] { ShareUIActivityType.PostToFacebook }
+                    ExcludedUIActivityTypes = new[] { ShareUIActivityType.PostToFacebook },
+                    PopoverAnchorRect = button.GetScreenRect()
                 });
-                
+
             };
 
             button1.Clicked += (sender, args) =>
@@ -70,8 +72,11 @@ namespace ShareTest
                     Text = "MotzCod.es",
                     Title = "heckout my blog",
                     Url = "http://motzcod.es"
+                }, new ShareOptions
+                {
+                    PopoverAnchorRect = button1.GetScreenRect()
                 });
-                
+
             };
 
             button2.Clicked += (sender, args) =>
@@ -82,7 +87,7 @@ namespace ShareTest
             buttonShare.Clicked += (sender, args) =>
             {
                 var shareMessage = new ShareMessage();
-                var shareOptions = new ShareOptions();
+                var shareOptions = new ShareOptions { PopoverAnchorRect = buttonShare.GetScreenRect() };
 
                 if (switchTitle.IsToggled)
                     shareMessage.Title = "MotzCod.es";

--- a/ShareTest/ShareTest/Extensions/VisualElementExtensions.cs
+++ b/ShareTest/ShareTest/Extensions/VisualElementExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Plugin.Share.Abstractions;
+using Xamarin.Forms;
+
+namespace ShareTest.Extensions
+{
+    public static class VisualElementExtensions
+    {
+
+        public static Rect GetScreenRect(this VisualElement view)
+        {
+            double screenCoordinateX = view.X;
+            double screenCoordinateY = view.Y;
+
+            if (view.Parent.GetType() != typeof(App))
+            {
+                VisualElement parent = (VisualElement)view.Parent;
+
+                // Loop through all parents
+                while (parent != null)
+                {
+                    // Add in the coordinates of the parent with respect to ITS parent
+                    screenCoordinateX += parent.X;
+                    screenCoordinateY += parent.Y;
+
+                    // If the parent of this parent isn't the app itself, get the parent's parent.
+                    if (parent.Parent.GetType() == typeof(App))
+                        parent = null;
+                    else
+                        parent = (VisualElement)parent.Parent;
+                }
+            }
+
+            return new Rect(screenCoordinateX, screenCoordinateY, view.Width, view.Height);
+        }
+
+
+    }
+}

--- a/ShareTest/ShareTest/Page1.xaml.cs
+++ b/ShareTest/ShareTest/Page1.xaml.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 using Xamarin.Forms;
+using Plugin.Share.Abstractions;
 
 namespace ShareTest
 {
@@ -19,7 +20,7 @@ namespace ShareTest
                 CrossShare.Current.Share(new Plugin.Share.Abstractions.ShareMessage
                 {
                     Text = "Follow @JamesMontemagno on Twitter",
-                    Title = "Share"
+                    Title = "Share",
                 });
             };
 

--- a/ShareTest/ShareTest/ShareTest.csproj
+++ b/ShareTest/ShareTest/ShareTest.csproj
@@ -42,6 +42,7 @@
       <DependentUpon>Page1.xaml</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Extensions\VisualElementExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="GettingStarted.Xamarin" />
@@ -67,31 +68,18 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.2.127\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.2.127\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.2.3.2.127\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Extensions\" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets'))" />
-  </Target>
-  <Import Project="..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <Import Project="..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/ShareTest/ShareTest/packages.config
+++ b/ShareTest/ShareTest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.3.2.127" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>


### PR DESCRIPTION
I implemented a very simple solution to the popover arrow problem, passing a new platform specific option to native implementation. 
The option is a rectangle indicating the anchored view (there is no such type in pcl projetcs, so I added a ShareRect class). Ios application running on iPads will render the popover arrow using this information.
@jguertl @jamesmontemagno 